### PR TITLE
chore: NEW_QUESTION 메시지가 두개 보내지는 문제 수정

### DIFF
--- a/src/pages/chat/ChatPage.jsx
+++ b/src/pages/chat/ChatPage.jsx
@@ -469,12 +469,6 @@ const ChatPage = () => {
   }, [isMemberIdsFetched]);
 
   const createNewQuestion = async () => {
-    // 에러 발생한 경우
-    // {
-    //   "code": "YET_ANSWER_BY_QUESTION",
-    //   "message": "아직 질문에 대답을 하지 않았습니다"
-    // }
-
     try {
       await instance.post('/question', {
         chatRoomId: roomId,
@@ -497,6 +491,7 @@ const ChatPage = () => {
     else if (lastMessage?.roomStatus === 'INACTIVE') setIsOpponentOut(true);
 
     if (
+      messages.length > 0 &&
       lastMessage?.checkTiKiTaKa !== 0 &&
       lastMessage?.checkTiKiTaKa % 3 === 0 &&
       lastMessage?.senderType !== 'NEW_QUESTION' &&


### PR DESCRIPTION
문제 상황 재연:
1. 유저 A, 유저 B가 있다고 가정
2. 유저 A가 유저 B와의 채팅방을 개설한 뒤 메시지를 보낸다. (tikitakaCount: 0)
3. tikitakaCount를 3으로 만든다. (유저 B가 메시지 전송할 때 NEW_QUESTION 메시지가 전송됨)
4. 생성된 질문에 답변하지 않고 tikitakaCount를 12로 만든다.
5. 유저 B는 채팅방 안에서 아까 지나온 질문에 대해 먼저 답변한다.
6. 유저 A는 트리 페이지로 들어가서 아까 지나온 질문에 대해 답변한다.
7. 유저 A가 트리 페이지에서 채팅 페이지로 나오면 NEW_QUESTION 메시지가 두개가 전송된다.

원인:
컴포넌트(혹은 페이지)가 최초 렌더링될 때 1회 실행하는 useEffect 훅의 특성 때문에 NEW_QUESTION 메시지가 2회 전송됨

해결:
useEffect 훅 내에서 messages.length > 0를 체크하는 조건문을 추가해줌으로서 해결